### PR TITLE
Update Solr settings in .lando.yml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,6 @@
 /docroot/profiles/contrib/
 /docroot/libraries/
 console/
-docroot/themes/custom/**/css/components/*.css
-docroot/themes/custom/**/css/plugins/*.css
-docroot/themes/custom/**/css/base/bootstrap.base.css
-docroot/themes/custom/**/css/rtl/base/vartheme_bs4-rtl.base.css
-docroot/themes/custom/**/css/theme/varbase-heroslider-media.theme.css
 
 # Ignore sensitive information
 /docroot/sites/*/settings.local.php

--- a/.lando.yml
+++ b/.lando.yml
@@ -21,9 +21,9 @@ services:
 #  memcache:
 #    type: memcached
 #  solr:
-#    type: solr:8.4
+#    type: solr:8.6
 #    config:
-#      dir: docroot/modules/contrib/search_api_solr/solr-conf/7.x
+#      dir: .platform/solr_8.x_config
 tooling:
   phpcs:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -22,6 +22,7 @@ services:
 #    type: memcached
 #  solr:
 #    type: solr:8.6
+#    core: drupal-solr
 #    config:
 #      dir: .platform/solr_8.x_config
 tooling:


### PR DESCRIPTION
## Description
In the .lando.yml file, change the default Solr directory location and default Solr version to be 8.6

## Related Issue
This project only accepts pull requests related to open issues.
- If suggesting a new feature or change, please discuss it in an issue first
- If fixing a bug, there should be an issue describing it with steps to reproduce it following the bug report guide
- If you're suggesting a feature, please follow the feature request guide by clicking on issues

### Please drop a link to the issue here:
https://github.com/Vardot/platformsh-varbase/issues/19

## Motivation and Context
Why is this change required? What problem does it solve?
Because this is a Platformsh Varbase template, it's critical for consistency.


## How Has This Been Tested?
Tested by run **_lando rebuild_** and **_lando inof_** commands to check if the new changes created a correct Solr server locally

## Screenshots (if appropriate):

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
 Go over all the following list, and put an `x` in all the boxes that apply. If you're unsure about what any of these mean, don't hesitate to ask. We're here to help!

- [x] I have read the contribution guide
- [x] I have created an issue following the issue guide
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
